### PR TITLE
Event class value objects

### DIFF
--- a/UnitTests/Common/Values/EventValues/EndEventDateTests.cs
+++ b/UnitTests/Common/Values/EventValues/EndEventDateTests.cs
@@ -1,0 +1,86 @@
+using ViaEventAssociation.Core.Domain.Aggregates.Events;
+using Xunit;
+
+namespace ViaEventAssociation.Core.Tests.Domain.Aggregates.Events;
+
+public class EndEventDateTests
+{
+    // Success Scenarios
+
+    //BUG: DateTime.Now
+    [Fact]
+    public void Create_ValidFutureEndDate_ReturnsSuccessResult()
+    {
+        // Arrange
+        DateTime validEndDate = DateTime.Now.AddDays(2).Date.AddHours(15); 
+
+        // Act
+        var result = EndEventDate.Create(validEndDate);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(validEndDate, result.Data.EndDateTime);
+    }
+
+    //BUG: DateTime.Now
+    [Fact]
+    public void Create_EndDateTodayAtValidTime_ReturnsSuccessResult()
+    {
+        // Arrange
+        DateTime validEndDate = DateTime.Now.Date.AddHours(21);
+
+        // Act
+        var result = EndEventDate.Create(validEndDate);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(validEndDate, result.Data.EndDateTime);
+    }
+
+    // Failure Scenarios
+
+    [Fact]
+    public void Create_EndDateInThePast_ReturnsFailureResult()
+    {
+        // Arrange
+        DateTime pastEndDate = DateTime.Now.Subtract(TimeSpan.FromDays(1)); 
+
+        // Act
+        var result = EndEventDate.Create(pastEndDate);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Event end date cannot be in the past.", result.Errors);
+    }
+
+    [Fact]
+    public void Create_ValidDateButBefore8am_ReturnsFailureResult()
+    {
+        // Arrange
+        DateTime invalidEndDate = DateTime.Now.AddDays(1).Date.AddHours(7); 
+
+        // Act
+        var result = EndEventDate.Create(invalidEndDate);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Event end time must be between 08:00 AM and 01:00 AM (next day).", result.Errors);
+    }
+
+    [Fact]
+    public void Create_ValidDateButAt1am_ReturnsFailureResult()
+    {
+        // Arrange
+        DateTime invalidEndDate = DateTime.Now.AddDays(1).Date.AddHours(1); 
+
+        // Act
+        var result = EndEventDate.Create(invalidEndDate);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Event end time must be between 08:00 AM and 01:00 AM (next day).", result.Errors);
+    }
+
+    // TODO: Tests for ensuring end date is after the start date 
+    // TODO: Tests for event duration not exceeding 10 hours
+}

--- a/UnitTests/Common/Values/EventValues/EventCapacityTests.cs
+++ b/UnitTests/Common/Values/EventValues/EventCapacityTests.cs
@@ -1,0 +1,53 @@
+using ViaEventAssociation.Core.Domain.Aggregates.Events;
+using Xunit;
+
+namespace ViaEventAssociation.Core.Tests.Domain.Aggregates.Events;
+
+public class EventCapacityTests
+{
+    // Success Scenarios 
+
+    [Theory]
+    [InlineData(5)]  
+    [InlineData(25)]
+    [InlineData(50)] 
+    public void Create_ValidCapacity_ReturnsSuccessResult(int capacityCount)
+    {
+        // Act
+        var result = Capacity.Create(capacityCount);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(capacityCount, result.Data.CapacityCount);
+    }
+
+    // Failure Scenarios
+
+    [Theory]
+    [InlineData(4)] 
+    [InlineData(0)]
+    [InlineData(-10)]
+    public void Create_CapacityLessThan5_ReturnsFailureResult(int capacityCount)
+    {
+        // Act
+        var result = Capacity.Create(capacityCount);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Capacity cannot be less than 5", result.Errors);
+    }
+
+    [Theory]
+    [InlineData(51)] 
+    [InlineData(60)]
+    [InlineData(100)] 
+    public void Create_CapacityGreaterThan50_ReturnsFailureResult(int capacityCount)
+    {
+        // Act
+        var result = Capacity.Create(capacityCount);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Capacity cannot be greater than 50", result.Errors);
+    }
+}

--- a/UnitTests/Common/Values/EventValues/EventDescriptionTests.cs
+++ b/UnitTests/Common/Values/EventValues/EventDescriptionTests.cs
@@ -1,0 +1,81 @@
+using ViaEventAssociation.Core.Domain.Aggregates.Events;
+using Xunit;
+
+namespace ViaEventAssociation.Core.Tests.Domain.Aggregates.Events;
+
+public class EventDescriptionTests
+{
+    // Success Scenarios
+
+    [Fact]
+    public void Create_ValidDescription_ReturnsSuccessResult()
+    {
+        // Arrange
+        string descriptionText = "This is a cool event you should attend!"; 
+
+        // Act
+        var result = Description.Create(descriptionText);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(descriptionText, result.Data.DescriptionText);
+    }
+
+    [Fact]
+    public void Create_DescriptionWithMaxLength_ReturnsSuccessResult()
+    {
+        // Arrange
+        string descriptionText = new string('X', 250);
+
+        // Act
+        var result = Description.Create(descriptionText);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(descriptionText, result.Data.DescriptionText);
+    }
+
+    // Failure Scenarios 
+
+    [Fact]
+    public void Create_NullDescription_ReturnsFailureResult()
+    {
+        // Arrange
+        string descriptionText = null;
+
+        // Act
+        var result = Description.Create(descriptionText);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Description cannot be null or empty.", result.Errors);
+    }
+
+    [Fact]
+    public void Create_EmptyDescription_ReturnsFailureResult()
+    {
+        // Arrange
+        string descriptionText = "";
+
+        // Act
+        var result = Description.Create(descriptionText);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Description cannot be null or empty.", result.Errors);
+    }
+
+    [Fact]
+    public void Create_DescriptionExceedingMaxLength_ReturnsFailureResult()
+    {
+        // Arrange
+        string descriptionText = new string('X', 251); 
+
+        // Act
+        var result = Description.Create(descriptionText);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Description cannot exceed 250 characters.", result.Errors);
+    }
+}

--- a/UnitTests/Common/Values/EventValues/EventIdTests.cs
+++ b/UnitTests/Common/Values/EventValues/EventIdTests.cs
@@ -1,0 +1,64 @@
+using ViaEventAssociation.Core.Domain.Aggregates.Events;
+using Xunit;
+
+namespace ViaEventAssociation.Core.Tests.Domain.Aggregates.Events;
+
+public class EventIdTests
+{
+    // Success Scenarios 
+
+    [Fact]
+    public void Create_GeneratesValidGuid_ReturnsSuccessResult()
+    {
+        // Act
+        var result = EventId.Create();
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotEqual(Guid.Empty, result.Data.Id);
+    }
+
+    [Fact]
+    public void Create_ValidGuidString_ReturnsSuccessResult()
+    {
+        // Arrange
+        var validGuidString = Guid.NewGuid().ToString();
+
+        // Act
+        var result = EventId.Create(validGuidString);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(Guid.Parse(validGuidString), result.Data.Id);
+    }
+
+    // Failure Scenarios 
+
+    [Fact]
+    public void Create_InvalidGuidString_ReturnsFailureResult()
+    {
+        // Arrange
+        string invalidGuidString = "not-a-valid-guid";
+
+        // Act
+        var result = EventId.Create(invalidGuidString);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Invalid EventId format.", result.Errors);
+    }
+
+    [Fact]
+    public void Create_EmptyGuidString_ReturnsFailureResult()
+    {
+        // Arrange
+        string emptyGuidString = "";
+
+        // Act
+        var result = EventId.Create(emptyGuidString);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Invalid EventId format.", result.Errors);
+    }
+}

--- a/UnitTests/Common/Values/EventValues/EventNameTests.cs
+++ b/UnitTests/Common/Values/EventValues/EventNameTests.cs
@@ -1,0 +1,96 @@
+using ViaEventAssociation.Core.Domain.Aggregates.Events;
+using Xunit;
+
+namespace ViaEventAssociation.Core.Tests.Domain.Aggregates.Events;
+
+public class EventNameTests
+{
+    // Success Scenarios
+
+    [Theory]
+    [InlineData("Valid Event Name")]
+    [InlineData("Another Cool Event")]
+    [InlineData("Meetup 2023")] 
+    public void Create_ValidTitle_ReturnsSuccessResult(string title)
+    {
+        // Act
+        var result = EventName.Create(title);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(title, result.Data.Title);
+    }
+
+
+    // Failure Scenarios 
+
+    [Fact]
+    public void Create_NullTitle_ReturnsFailureResult()
+    {
+        // Arrange
+        string title = null;
+
+        // Act
+        var result = EventName.Create(title);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Title cannot be NULL or Empty.", result.Errors);
+    }
+
+    [Fact]
+    public void Create_EmptyTitle_ReturnsFailureResult()
+    {
+        // Arrange
+        string title = ""; 
+
+        // Act
+        var result = EventName.Create(title);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Title cannot be NULL or Empty.", result.Errors);
+    }
+
+    [Fact]
+    public void Create_WhitespaceTitle_ReturnsFailureResult()
+    {
+        // Arrange
+        string title = "   ";  
+
+        // Act
+        var result = EventName.Create(title);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Title cannot bee a white space.", result.Errors);
+    }
+
+    [Fact]
+    public void Create_TitleLessThan3Chars_ReturnsFailureResult()
+    {
+        // Arrange
+        string title = "AB";
+
+        // Act
+        var result = EventName.Create(title);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Title cannot be less than 3 characters.", result.Errors);
+    }
+
+    [Fact]
+    public void Create_TitleMoreThan75Chars_ReturnsFailureResult()
+    {
+        // Arrange
+        string title = new string('X', 76);
+
+        // Act
+        var result = EventName.Create(title);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Title cannot be more than 75 characters.", result.Errors);
+    }
+}

--- a/UnitTests/Common/Values/EventValues/StartEventDateTests.cs
+++ b/UnitTests/Common/Values/EventValues/StartEventDateTests.cs
@@ -1,0 +1,84 @@
+using ViaEventAssociation.Core.Domain.Aggregates.Events;
+using Xunit;
+
+namespace ViaEventAssociation.Core.Tests.Domain.Aggregates.Events;
+
+public class StartEventDateTests
+{
+    // Success Scenarios 
+
+    [Fact]
+    public void Create_ValidFutureDate_ReturnsSuccessResult()
+    {
+        // Arrange
+        DateTime validDate = DateTime.Now.AddDays(2).Date.AddHours(10);
+
+        // Act
+        var result = StartEventDate.Create(validDate);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(validDate, result.Data.Date);
+    }
+
+    // BUG: This test is failing because of the DateTime.Now
+    [Fact]
+    public void Create_DateTodayAtValidTime_ReturnsSuccessResult()
+    {
+        // Arrange
+        var frozenNow = DateTime.Now;
+        DateTime validDate = frozenNow.AddHours(15);
+
+        // Act
+        var result = StartEventDate.Create(validDate);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(validDate, result.Data.Date);
+    }
+
+
+    // Failure Scenarios 
+
+    [Fact]
+    public void Create_DateInThePast_ReturnsFailureResult()
+    {
+        // Arrange
+        DateTime pastDate = DateTime.Now.Subtract(TimeSpan.FromDays(1));
+
+        // Act
+        var result = StartEventDate.Create(pastDate);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Event start date cannot be in the past.", result.Errors);
+    }
+
+    [Fact]
+    public void Create_ValidDateButBefore8am_ReturnsFailureResult()
+    {
+        // Arrange
+        DateTime invalidDate = DateTime.Now.AddDays(1).Date.AddHours(7); 
+
+        // Act
+        var result = StartEventDate.Create(invalidDate);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Event start time must be between 08:00 AM and 11:59 PM.", result.Errors);
+    }
+
+    [Fact]
+    public void Create_ValidDateButAtMidnight_ReturnsFailureResult()
+    {
+         // Arrange
+        DateTime invalidDate = DateTime.Now.AddDays(1).Date;
+
+        // Act
+        var result = StartEventDate.Create(invalidDate);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Event start time must be between 08:00 AM and 11:59 PM.", result.Errors);
+    }
+}

--- a/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/Capacity.cs
+++ b/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/Capacity.cs
@@ -1,0 +1,41 @@
+using ViaEventAssociation.Core.Tools.OperationResult;
+
+namespace ViaEventAssociation.Core.Domain.Aggregates.Events;
+
+public class Capacity
+{
+    public int CapacityCount { get; private set; }
+
+    private Capacity(int capacityCount)
+    {
+        CapacityCount = capacityCount;
+    }
+
+    public static Result<Capacity> Create(int capacityCount)
+    {
+        var validationResult = Validate(capacityCount);
+        if (!validationResult.IsSuccess)
+        {
+            return Result<Capacity>.Failure(validationResult.Errors.ToArray());
+        }
+
+        return Result<Capacity>.Success(new Capacity(capacityCount));
+    }
+
+    private static Result Validate(int capacityCount)
+    {
+        var errors = new List<string>();
+
+        if (capacityCount < 5)
+        {
+            errors.Add("Capacity cannot be less than 5");
+        }
+
+        if (capacityCount > 50)
+        {
+            errors.Add("Capacity cannot be greater than 50");
+        }
+
+        return errors.Any() ? Result.Failure(errors.ToArray()) : Result.Success();
+    }
+}

--- a/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/Description.cs
+++ b/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/Description.cs
@@ -1,0 +1,41 @@
+using ViaEventAssociation.Core.Tools.OperationResult;
+
+namespace ViaEventAssociation.Core.Domain.Aggregates.Events;
+
+public class Description
+{
+    public string DescriptionText { get; private set; }
+
+    private Description(string descriptionText)
+    {
+        DescriptionText = descriptionText;
+    }
+
+    public static Result<Description> Create(string descriptionText)
+    {
+        var validationResult = Validate(descriptionText);
+        if (!validationResult.IsSuccess)
+        {
+            return Result<Description>.Failure(validationResult.Errors.ToArray());
+        }
+
+        return Result<Description>.Success(new Description(descriptionText));
+    }
+
+    private static Result Validate(string descriptionText)
+    {
+        var errors = new List<string>();
+
+        if (string.IsNullOrEmpty(descriptionText))
+        {
+            errors.Add("Description cannot be null or empty.");
+        }
+
+        if (descriptionText.Length > 250)
+        {
+            errors.Add("Description cannot exceed 250 characters.");
+        }
+
+        return errors.Any() ? Result.Failure(errors.ToArray()) : Result.Success();
+    }
+}

--- a/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/EndEventDate.cs
+++ b/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/EndEventDate.cs
@@ -1,0 +1,48 @@
+using ViaEventAssociation.Core.Tools.OperationResult;
+
+namespace ViaEventAssociation.Core.Domain.Aggregates.Events;
+
+public class EndEventDate
+{
+    public DateTime EndDateTime { get; private set; }
+
+    private EndEventDate(DateTime endDateTime)
+    {
+        EndDateTime = endDateTime;
+    }
+
+    public static Result<EndEventDate> Create(DateTime endDateTime)
+    {
+        var validationResult = Validate(endDateTime);
+        if (!validationResult.IsSuccess)
+        {
+            return Result<EndEventDate>.Failure(validationResult.Errors.ToArray());
+        }
+
+        return Result<EndEventDate>.Success(new EndEventDate(endDateTime));
+    }
+
+    private static Result Validate(DateTime endDateTime)
+    {
+        var errors = new List<string>();
+
+        if (endDateTime < DateTime.Now)  
+        {
+            errors.Add("Event end date cannot be in the past.");
+        }
+
+        if (endDateTime.TimeOfDay < new TimeSpan(8, 0, 0) || 
+            endDateTime.TimeOfDay >= new TimeSpan(1, 0, 0)) 
+        {
+            errors.Add("Event end time must be between 08:00 AM and 01:00 AM (next day).");
+        }
+
+        // TODO: Discuss with teacher
+        // End date must be after the start date 
+
+        // TODO: Discuss with teacher
+        // Event duration cannot exceed 10 hours
+
+        return errors.Any() ? Result.Failure(errors.ToArray()) : Result.Success();
+    }
+}

--- a/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/EventId.cs
+++ b/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/EventId.cs
@@ -1,0 +1,42 @@
+using ViaEventAssociation.Core.Tools.OperationResult;
+
+namespace ViaEventAssociation.Core.Domain.Aggregates.Events;
+
+public class EventId
+{
+    public Guid Id { get; private set; } 
+
+    private EventId(Guid id)
+    {
+        Id = id;
+    }
+
+    public static Result<EventId> Create()
+    {
+        var eventId = new EventId(Guid.NewGuid());
+        return Result<EventId>.Success(eventId);
+    }
+
+    public static Result<EventId> Create(string eventIdString)
+    {
+        var validationResult = Validate(eventIdString);
+        if (!validationResult.IsSuccess)
+        {
+            return Result<EventId>.Failure(validationResult.Errors.ToArray());
+        }
+
+        return Result<EventId>.Success(new EventId(Guid.Parse(eventIdString)));
+    }
+
+    private static Result Validate(string eventIdString)
+    {
+        var errors = new List<string>();
+
+        if (!Guid.TryParse(eventIdString, out _))
+        {
+             errors.Add("Invalid EventId format.");
+        }
+
+        return errors.Any() ? Result.Failure(errors.ToArray()) : Result.Success();
+    }
+}

--- a/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/EventName.cs
+++ b/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/EventName.cs
@@ -29,23 +29,25 @@ public class EventName
         if (string.IsNullOrEmpty(title))
         {
             errors.Add("Title cannot be NULL or Empty.");
-        }
-
-        if (string.IsNullOrWhiteSpace(title))
+        } else 
         {
-            errors.Add("Title cannot bee a white space.");
-        }
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                errors.Add("Title cannot bee a white space.");
+            }
 
-        if (title.Length < 3)
-        {
-            errors.Add("Title cannot be less than 3 characters.");
-        }
+            if (title.Length < 3)
+            {
+                errors.Add("Title cannot be less than 3 characters.");
+            }
 
-        if (title.Length > 75)
-        {
-            errors.Add("Title cannot be more than 75 characters.");
-        }
+            if (title.Length > 75)
+            {
+                errors.Add("Title cannot be more than 75 characters.");
+            }
+        } 
 
         return errors.Any() ? Result.Failure(errors.ToArray()) : Result.Success();
     }
+
 }

--- a/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/EventName.cs
+++ b/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/EventName.cs
@@ -1,0 +1,51 @@
+using ViaEventAssociation.Core.Tools.OperationResult;
+
+namespace ViaEventAssociation.Core.Domain.Aggregates.Events;
+
+public class EventName
+{
+    public string Title { get; private set;}
+
+    private EventName(string title)
+    {
+        Title = title;
+    }
+
+    public static Result<EventName> Create(string title)
+    {
+        var validate = Validate(title);
+        if (!validate.IsSuccess)
+        {
+            return Result<EventName>.Failure(validate.Errors.ToArray());
+        }
+
+        return Result<EventName>.Success(new EventName(title));
+    }
+
+    private static Result Validate(string title)
+    {
+        var errors = new List<string>();
+
+        if (string.IsNullOrEmpty(title))
+        {
+            errors.Add("Title cannot be NULL or Empty.");
+        }
+
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            errors.Add("Title cannot bee a white space.");
+        }
+
+        if (title.Length < 3)
+        {
+            errors.Add("Title cannot be less than 3 characters.");
+        }
+
+        if (title.Length > 75)
+        {
+            errors.Add("Title cannot be more than 75 characters.");
+        }
+
+        return errors.Any() ? Result.Failure(errors.ToArray()) : Result.Success();
+    }
+}

--- a/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/StartEventDate.cs
+++ b/ViaEventAssociation.Core.Domain/Aggregates/ViaEvents/ValueObjects/StartEventDate.cs
@@ -1,0 +1,42 @@
+using ViaEventAssociation.Core.Tools.OperationResult;
+
+namespace ViaEventAssociation.Core.Domain.Aggregates.Events;
+
+public class StartEventDate
+{
+    public DateTime Date { get; private set; } 
+
+    private StartEventDate(DateTime date)
+    {
+        Date = date;
+    }
+
+    public static Result<StartEventDate> Create(DateTime date)
+    {
+        var validationResult = Validate(date);
+        if (!validationResult.IsSuccess)
+        {
+            return Result<StartEventDate>.Failure(validationResult.Errors.ToArray());
+        }
+
+        return Result<StartEventDate>.Success(new StartEventDate(date));
+    }
+
+    private static Result Validate(DateTime date)
+    {
+        var errors = new List<string>();
+
+        if (date < DateTime.Now)  
+        {
+            errors.Add("Event start date cannot be in the past.");
+        }
+
+        if (date.TimeOfDay < new TimeSpan(8, 0, 0) || 
+            date.TimeOfDay >= new TimeSpan(23, 59, 59)) 
+        {
+            errors.Add("Event start time must be between 08:00 AM and 11:59 PM.");
+        }
+
+        return errors.Any() ? Result.Failure(errors.ToArray()) : Result.Success();
+    }
+}


### PR DESCRIPTION
EndEventDate is missing two validations, subject for further discussions.
EndEventDate and StartEventDate have 3 test cases in total that are failing because of using DateTime.Now, also something to discuss with the teacher or in the group.